### PR TITLE
Added block callback for prev/next changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ If you want to have total control over what the **Previous** and **Next** button
 1. Find all text fields and editable text views in the key window
 2. Sort them using their frame origin vertical position
 
+If you need notification of **Previous** and **Next** button presses, use the optional `changeBlock` property to add a block-based callback (but beware of `self` retain cycles!).
+
 License
 =======
 The MIT License (MIT)

--- a/XCDFormInputAccessoryView/XCDFormInputAccessoryView.h
+++ b/XCDFormInputAccessoryView/XCDFormInputAccessoryView.h
@@ -7,6 +7,8 @@
 
 #import <UIKit/UIKit.h>
 
+typedef void(^XCDFormInputAccessoryViewChangeBlock)(UIResponder *newResponder);
+
 @interface XCDFormInputAccessoryView : UIView
 
 - (id) initWithResponders:(NSArray *)responders; // Objects must be UIResponder instances
@@ -14,6 +16,8 @@
 @property (nonatomic, strong) NSArray *responders;
 
 @property (nonatomic, assign) BOOL hasDoneButton; // Defaults to YES on iPhone, NO on iPad
+
+@property (nonatomic, copy) XCDFormInputAccessoryViewChangeBlock changeBlock;
 
 - (void) setHasDoneButton:(BOOL)hasDoneButton animated:(BOOL)animated;
 

--- a/XCDFormInputAccessoryView/XCDFormInputAccessoryView.h
+++ b/XCDFormInputAccessoryView/XCDFormInputAccessoryView.h
@@ -7,7 +7,7 @@
 
 #import <UIKit/UIKit.h>
 
-typedef void(^XCDFormInputAccessoryViewChangeBlock)(UIResponder *newResponder);
+typedef void(^XCDFormInputAccessoryViewChangeBlock)(UIResponder *newFirstResponder);
 
 @interface XCDFormInputAccessoryView : UIView
 

--- a/XCDFormInputAccessoryView/XCDFormInputAccessoryView.m
+++ b/XCDFormInputAccessoryView/XCDFormInputAccessoryView.m
@@ -155,6 +155,9 @@ static NSArray * EditableTextInputsInView(UIView *view)
 	if (adjacentResponderIndex >= 0 && adjacentResponderIndex < (NSInteger)[self.responders count])
 		adjacentResponder = [self.responders objectAtIndex:adjacentResponderIndex];
 	
+    if (self.changeBlock) 
+        self.changeBlock(adjacentResponder);
+    
 	[adjacentResponder becomeFirstResponder];
 }
 


### PR DESCRIPTION
I added a block callback that fires whenever the Next/Previous buttons are pressed, in order to get XCDFormInputAccessoryView to play nice with [TPKeyboardAvoiding](https://github.com/michaeltyson/TPKeyboardAvoiding).

I found that I could press Next until the active text field was way offscreen, and needed to fire TPKeyboardAvoiding's `-scrollToActiveTextField` method to move it into the visible area. 

If there's already an easy way to do this I totally missed it...but this callback might be useful for other things as well.
