### PR TITLE
fixes an iOS5 issue with non-reactivating segment in Previous/Next-control

### DIFF
--- a/XCDFormInputAccessoryView.podspec
+++ b/XCDFormInputAccessoryView.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+s.name         = "XCDFormInputAccessoryView"
+s.version      = "1.0.0-kfi"
+s.summary      = "Input accessory view with previous, next and done buttons."
+s.homepage     = "https://github.com/0xced/XCDFormInputAccessoryView"
+s.license      = { :type => 'MIT', :file => 'README.md' }
+s.author       = { "Cédric Luthi" => "cedric.luthi@gmail.com" }
+s.source       = { :git => "https://ricobeck@github.com/ricobeck/XCDFormInputAccessoryView.git", :branch => "develop" }
+s.platform     = :ios
+s.source_files = 'XCDFormInputAccessoryView'
+s.requires_arc = true
+end

--- a/XCDFormInputAccessoryView.podspec.json
+++ b/XCDFormInputAccessoryView.podspec.json
@@ -1,0 +1,22 @@
+{
+  "name": "XCDFormInputAccessoryView",
+  "version": "1.0.0-kfi",
+  "summary": "Input accessory view with previous, next and done buttons.",
+  "homepage": "https://github.com/0xced/XCDFormInputAccessoryView",
+  "license": {
+    "type": "MIT",
+    "file": "README.md"
+  },
+  "authors": {
+    "Cédric Luthi": "cedric.luthi@gmail.com"
+  },
+  "source": {
+    "git": "https://ricobeck@github.com/ricobeck/XCDFormInputAccessoryView.git",
+    "branch": "develop"
+  },
+  "platforms": {
+    "ios": null
+  },
+  "source_files": "XCDFormInputAccessoryView",
+  "requires_arc": true
+}

--- a/XCDFormInputAccessoryView/XCDFormInputAccessoryView.m
+++ b/XCDFormInputAccessoryView/XCDFormInputAccessoryView.m
@@ -83,6 +83,8 @@ static NSArray * EditableTextInputsInView(UIView *view)
 	UISegmentedControl *segmentedControl = (UISegmentedControl *)[_toolbar.items[0] customView];
 	BOOL isFirst = [[responders objectAtIndex:0] isFirstResponder];
 	BOOL isLast = [[responders lastObject] isFirstResponder];
+    
+    segmentedControl.selectedSegmentIndex = UISegmentedControlNoSegment;
 	[segmentedControl setEnabled:!isFirst forSegmentAtIndex:0];
 	[segmentedControl setEnabled:!isLast forSegmentAtIndex:1];
 }


### PR DESCRIPTION
the next button was stuck in it's highlight state due to an iOS5 bug. deselecting all segments fixes this.
